### PR TITLE
Add AnimeJS transition between fader screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,14 +80,37 @@
       }
 
       /* Main Content Styles */
-      .fader-area {
-        height: 342px;
-        background-color: #d4cbc4;
-        border-radius: 29px;
-        box-shadow: inset 1px 1px 3px #908a85e6, inset -1px -1px 2px #ffffffe6, inset 1px -1px 2px #908a8533,
-          inset -1px 1px 2px #908a8533, -1px -1px 2px #908a8580, 1px 1px 2px #ffffff4c;
-        margin-bottom: 20px;
-      }
+        .fader-area {
+          height: 342px;
+          background-color: #d4cbc4;
+          border-radius: 29px;
+          box-shadow: inset 1px 1px 3px #908a85e6, inset -1px -1px 2px #ffffffe6, inset 1px -1px 2px #908a8533,
+            inset -1px 1px 2px #908a8533, -1px -1px 2px #908a8580, 1px 1px 2px #ffffff4c;
+          margin-bottom: 0;
+        }
+
+        .fader-container {
+          position: relative;
+          height: 450px;
+          margin-bottom: 20px;
+          overflow: hidden;
+        }
+
+        .fader-container .fader-area {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+        }
+
+        .ActiveScreenFxMenu {
+          transform: translateY(100%);
+        }
+
+        .ActiveScreenLargeFader {
+          transform: translateY(0%);
+        }
 
       .available-tracks {
         display: flex;
@@ -230,10 +253,11 @@
       }
 
       /* Selected state styles for monitor buttons */
-      .ButtonComponent.selected .Label {
+    .ButtonComponent.selected .Label {
         font-weight: 800;
       }
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script>
       // Scroll lock state
       let isScrollLocked = false;
@@ -349,18 +373,38 @@
         const fxMenuScreen = document.querySelector('.ActiveScreenFxMenu');
         const optionsIcons = document.querySelectorAll('.OptionsIcon');
 
+        let showingFx = false;
+
         optionsIcons.forEach(icon => {
           icon.addEventListener('click', function() {
-            // Toggle between screens
-            if (largeFaderScreen.style.display !== 'none') {
-              // Show FX Menu, hide Large Fader
-              largeFaderScreen.style.display = 'none';
-              fxMenuScreen.style.display = 'flex';
+            if (!showingFx) {
+              anime({
+                targets: largeFaderScreen,
+                translateY: '-100%',
+                duration: 500,
+                easing: 'easeInOutQuad'
+              });
+              anime({
+                targets: fxMenuScreen,
+                translateY: '0%',
+                duration: 500,
+                easing: 'easeInOutQuad'
+              });
             } else {
-              // Show Large Fader, hide FX Menu
-              fxMenuScreen.style.display = 'none';
-              largeFaderScreen.style.display = 'flex';
+              anime({
+                targets: fxMenuScreen,
+                translateY: '100%',
+                duration: 500,
+                easing: 'easeInOutQuad'
+              });
+              anime({
+                targets: largeFaderScreen,
+                translateY: '0%',
+                duration: 500,
+                easing: 'easeInOutQuad'
+              });
             }
+            showingFx = !showingFx;
           });
         });
 
@@ -1138,6 +1182,7 @@
         </div>
       </header>
       <main>
+        <div class="fader-container">
         <div data-layer="Active-Screen=Large Fader" class="ActiveScreenLargeFader fader-area" style="width: 100%; height: 450px; padding-left: 10px; padding-right: 10px; padding-top: 20px; padding-bottom: 20px; background: #D4CBC4; box-shadow: inset 1px 1px 3px #908a85e6, inset -1px -1px 2px #ffffffe6, inset 1px -1px 2px #908a8533, inset -1px 1px 2px #908a8533, -1px -1px 2px #908a8580, 1px 1px 2px #ffffff4c; border-radius: 29px; flex-direction: column; justify-content: center; align-items: center; gap: 12px; display: flex; margin-bottom: 20px;">
           <div data-layer="dB Reading" class="DbReading" style="align-self: stretch; height: 48px; overflow: hidden; justify-content: flex-start; align-items: flex-start; display: inline-flex">
             <div data-layer="Spacer" class="Spacer" style="flex: 1 1 0; align-self: stretch; padding: 10px"></div>
@@ -1203,7 +1248,7 @@
           </div>
         </div>
         
-        <div data-layer="Active-Screen=FX Menu" class="ActiveScreenFxMenu fader-area" style="width: 100%; height: 450px; padding-left: 10px; padding-right: 10px; padding-top: 20px; padding-bottom: 20px; background: #D4CBC4; box-shadow: inset 1px 1px 3px #908a85e6, inset -1px -1px 2px #ffffffe6, inset 1px -1px 2px #908a8533, inset -1px 1px 2px #908a8533, -1px -1px 2px #908a8580, 1px 1px 2px #ffffff4c; border-radius: 29px; flex-direction: column; justify-content: flex-start; align-items: center; display: none; margin-bottom: 20px;">
+        <div data-layer="Active-Screen=FX Menu" class="ActiveScreenFxMenu fader-area" style="width: 100%; height: 450px; padding-left: 10px; padding-right: 10px; padding-top: 20px; padding-bottom: 20px; background: #D4CBC4; box-shadow: inset 1px 1px 3px #908a85e6, inset -1px -1px 2px #ffffffe6, inset 1px -1px 2px #908a8533, inset -1px 1px 2px #908a8533, -1px -1px 2px #908a8580, 1px 1px 2px #ffffff4c; border-radius: 29px; flex-direction: column; justify-content: flex-start; align-items: center; display: flex; margin-bottom: 20px;">
           <div data-layer="dB Reading" class="DbReading" style="align-self: stretch; height: 48px; overflow: hidden; justify-content: flex-start; align-items: flex-start; display: inline-flex">
             <div data-layer="Spacer" class="Spacer" style="flex: 1 1 0; align-self: stretch; padding: 10px"></div>
             <div data-layer="Current dB Wrapper" class="CurrentDbWrapper" style="flex: 1 1 0; align-self: stretch; flex-direction: column; justify-content: flex-end; align-items: center; gap: 10px; display: inline-flex"></div>
@@ -1357,6 +1402,7 @@
           </div>
         </div>
         
+        </div>
         <div class="available-tracks">
           <div class="track selected" role="button" aria-label="Guitar 1">
             <div class="track-name">Guitar 1</div>


### PR DESCRIPTION
## Summary
- create new `fader-container` wrapper so screens can slide
- add AnimeJS via CDN
- animate screen transitions with AnimeJS instead of toggling display
- style fader container and screens for sliding animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68869a00871c83259b349cc2764b0989